### PR TITLE
Remove unnecessary docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,23 +30,6 @@ services:
     depends_on:
       - actions
 
-  # ================================= RASA X ==================================
-  # Rasa X container
-  x:
-    build:
-      context: .
-      dockerfile: ./docker/bot.Dockerfile
-    restart: unless-stopped
-    volumes:
-      - ./bot/:/bot/
-    ports:
-      - 5002:5002
-    env_file:
-      - env/rasax.env
-    depends_on:
-      - actions
-    command: sh -c "make x"
-
   # ================================= Actions =================================
   # Rasa middleware used to connect with external APIs.
   actions:
@@ -58,56 +41,6 @@ services:
     volumes:
       - ./bot/actions:/bot/actions
     command: sh -c "make actions"
-
-  # ============================ WebChat Bot =================================
-  # Specific Rasa bot integrated with WebChat.
-  bot-webchat-core1:
-      build:
-        context: .
-        dockerfile: ./docker/bot.Dockerfile
-      volumes:
-        - ./bot/:/bot/
-      depends_on:
-        - actions
-      command: sh -c "make webchat"
-
-  bot-webchat-core2:
-      build:
-        context: .
-        dockerfile: ./docker/bot.Dockerfile
-      volumes:
-        - ./bot/:/bot/
-      depends_on:
-        - actions
-      command: sh -c "make webchat"
-
-  # =========================== Loadbalancer =================================
-  # HAProxy used as loadbalancer for more than 1 instance of bot-webchat
-  # Use case for load balacing websockets
-  bot-webchat:
-    image: haproxy:2.3
-    volumes:
-      - "./modules/haproxy/:/usr/local/etc/haproxy:ro"
-    ports:
-      - 5007:5007
-      - 32700:32700
-    depends_on:
-      - bot-webchat-core1
-      - bot-webchat-core2
-
-  # ============================ WebChat Bot =================================
-  # Specific Rasa bot integrated with WebChat.
-  bot-rocket:
-      build:
-        context: .
-        dockerfile: ./docker/bot.Dockerfile
-      volumes:
-        - ./bot/:/bot/
-      ports:
-        - 5005:5005
-      depends_on:
-        - actions
-      command: sh -c "make rocket"
 
   # =============================== Analytics =================================
   # Analitics ElasticSearch Stack.
@@ -167,16 +100,6 @@ services:
       - env/rabbitmq-consumer.env
     command: python3 /opt/scripts/consume_bot_messages.py
 
-
-  # ============================ Webchat Page  =================================
-  # A container to run webchat html page
-  webchat:
-    image: nginx
-    ports:
-      - 5010:80
-    volumes:
-      - ./modules/webchat:/usr/share/nginx/html
-
   # ============================ Telegram Bot =================================
   # Specific Rasa bot integrated with Telegram.
   bot_telegram:
@@ -222,61 +145,6 @@ services:
       - ./bot/:/bot/
     ports:
       - 8888:8888
-
-  # =============================== Rocket.Chat =================================
-  # Rocket.Chat instance and database
-  rocketchat:
-    image: rocketchat/rocket.chat:3.7.1
-    command: >
-      bash -c
-        "for i in `seq 1 30`; do
-          node main.js &&
-          s=$$? && break || s=$$?;
-          echo \"Tried $$i times. Waiting 5 secs...\";
-          sleep 5;
-        done; (exit $$s)"
-    restart: unless-stopped
-    volumes:
-      - rocket_uploads:/app/uploads
-    environment:
-      - PORT=3000
-      - ROOT_URL=http://localhost:3000
-      - MONGO_URL=mongodb://mongo:27017/rocketchat
-      - MONGO_OPLOG_URL=mongodb://mongo:27017/local
-      - ADMIN_USERNAME=admin
-      - ADMIN_PASS=admin
-      - ADMIN_EMAIL=mail@mail.com
-    depends_on:
-      - mongo
-      - mongo-init-replica
-    ports:
-      - 5003:3000
-
-  mongo:
-    image: mongo:4.0
-    restart: unless-stopped
-    volumes:
-     - mongo_data:/data/db
-    command: mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=mmapv1
-
-  # this container's job is just run the command to initialize the replica set.
-  # it will run the command and remove himself (it will not stay running)
-  mongo-init-replica:
-    image: mongo:4.0
-    command: >
-      bash -c
-        "for i in `seq 1 30`; do
-          mongo mongo/rocketchat --eval \"
-            rs.initiate({
-              _id: 'rs0',
-              members: [ { _id: 0, host: 'localhost:27017' } ]})\" &&
-          s=$$? && break || s=$$?;
-          echo \"Tried $$i times. Waiting 5 secs...\";
-          sleep 5;
-        done; (exit $$s)"
-    depends_on:
-      - mongo
-
 volumes:
   notebook_models:
   mongo_data:
@@ -284,4 +152,3 @@ volumes:
   esbackup:
   esdata:
     driver: local
-  rocket_uploads:


### PR DESCRIPTION
## Summary

Removing sections of the docker-compose file that hold services we will not be running on this prototype that came from the boilerplate. This is going to provide the groundwork for me to migrate this to run on a kube cluster.

## How I tested

Running the following to make sure the docker-compose can still be used for local development.
```
make build
make run-twilio
```